### PR TITLE
bugfix_search_for_opponent_includes_your_own_name

### DIFF
--- a/src/pages/player/MatchHistory.tsx
+++ b/src/pages/player/MatchHistory.tsx
@@ -23,7 +23,7 @@ export default function MatchHistory({
 
   if (!data || isLoading) return null;
 
-  const filteredMatches = filterMatches(data, searchQuery);
+  const filteredMatches = filterMatches(data, searchQuery, id);
 
   return (
     <>

--- a/src/pages/player/PlayerEloGraph.tsx
+++ b/src/pages/player/PlayerEloGraph.tsx
@@ -22,7 +22,7 @@ export default function PlayerEloGraph({ id, searchQuery }: Props) {
   if (!data || isLoading) return null;
   if (!matchs || matchsIsLoading) return null;
 
-  const filteredMatches = filterMatches(matchs, searchQuery);
+  const filteredMatches = filterMatches(matchs, searchQuery, id);
   const { graphData, min, max } = getGraphData(filteredMatches, id, data.elo);
 
   return (

--- a/src/pages/player/PlayerOpponentRadar.tsx
+++ b/src/pages/player/PlayerOpponentRadar.tsx
@@ -21,7 +21,7 @@ export default function PlayerOpponentRadar({ id, searchQuery }: Props) {
   if (!data || isLoading) return null;
   if (!matchs || matchsIsLoading) return null;
 
-  const filteredMatches = filterMatches(matchs, searchQuery);
+  const filteredMatches = filterMatches(matchs, searchQuery, id);
   const { radarData } = getRadarData(filteredMatches, id);
 
   if (radarData.length < 3) return null;

--- a/src/utils/match.ts
+++ b/src/utils/match.ts
@@ -24,10 +24,11 @@ export const getMatchStats = (matches: TableTennisMatch[], id: string) => {
 export function filterMatches(
   matches: TableTennisMatch[],
   searchQuery: string,
+  id: string,
 ) {
   const letters = searchQuery.split("");
 
-  const player1Matches = matches.filter((match) => {
+  const filteredMatches = matches.filter((match) => {
     return letters.reduce(
       (acc, letter) => {
         if (!acc.state) return { state: acc.state, name: acc.name };
@@ -37,27 +38,17 @@ export function filterMatches(
           name: acc.name.replace(letter.toLowerCase(), ""),
         };
       },
-      { state: true, name: match.player1Id.toLowerCase() },
-    ).state;
-  });
-
-  const player2Matches = matches.filter((match) => {
-    return letters.reduce(
-      (acc, letter) => {
-        if (!acc.state) return { state: acc.state, name: acc.name };
-        const includesLetter = acc.name.includes(letter.toLowerCase());
-        return {
-          state: includesLetter,
-          name: acc.name.replace(letter.toLowerCase(), ""),
-        };
+      {
+        state: true,
+        name:
+          match.winner === id
+            ? match.player2Id.toLowerCase()
+            : match.player1Id.toLowerCase(),
       },
-      { state: true, name: match.player2Id.toLowerCase() },
     ).state;
   });
 
-  return [...new Set(player1Matches.concat(player2Matches))].sort(
-    sortMatchesByDate,
-  );
+  return filteredMatches;
 }
 
 export const getTime = (date: Date) => {


### PR DESCRIPTION
when searching for opponent, the search result use both names. But one of the names is you, so the search should only use the player that is not you